### PR TITLE
Implement automatic monitoring system deployment with cluster provisioning  

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -1,24 +1,41 @@
 ---
-- name: Install monitoring stack
+- name: Deploy monitoring stack
   hosts: kafka_cluster
+  vars:
+    prometheus_version: "2.47.0"
+    grafana_version: "9.5.6"
+    kafka_exporter_version: "1.7.0"
+    
   tasks:
-    - name: Install Prometheus
-      apt: 
+    - name: Install Prometheus Operator
+      helm:
         name: prometheus
-        state: present
+        chart_name: prometheus-community/kube-prometheus-stack
+        namespace: monitoring
+        create_namespace: true
+        values:
+          prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues: false
+          grafana.sidecar.dashboards.enabled: true
+          grafana.sidecar.dashboards.label: grafana_dashboard
+
+    - name: Deploy Kafka Exporter
+      kubernetes.core.helm:
+        name: kafka-exporter
+        chart_ref: prometheus-community/prometheus-kafka-exporter
+        version: "{{ kafka_exporter_version }}"
+        namespace: monitoring
         
-    - name: Configure Kafka exporter
+    - name: Import Grafana dashboards
       template:
-        src: templates/kafka_exporter.conf.j2
-        dest: /etc/prometheus/kafka_exporter.conf
-        
-    - name: Start Prometheus service
-      service:
-        name: prometheus
-        state: started
-        
-    - name: Install Grafana
-      apt:
+        src: ../../configs/grafana/dashboard.json
+        dest: /etc/grafana/provisioning/dashboards/kafka.json
+      notify: Restart Grafana
+
+  handlers:
+    - name: Restart Grafana
+      kubernetes.core.k8s:
+        kind: Deployment
         name: grafana
-        state: present
+        namespace: monitoring
+        state: restarted
 

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -1,41 +1,27 @@
----
-- name: Deploy monitoring stack
-  hosts: kafka_cluster
-  vars:
-    prometheus_version: "2.47.0"
-    grafana_version: "9.5.6"
-    kafka_exporter_version: "1.7.0"
-    
-  tasks:
-    - name: Install Prometheus Operator
-      helm:
-        name: prometheus
-        chart_name: prometheus-community/kube-prometheus-stack
-        namespace: monitoring
-        create_namespace: true
-        values:
-          prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues: false
-          grafana.sidecar.dashboards.enabled: true
-          grafana.sidecar.dashboards.label: grafana_dashboard
+- name: Configure AlertManager
+  helm:
+    name: prometheus
+    chart_name: prometheus-community/kube-prometheus-stack
+    namespace: monitoring
+    values:
+      alertmanager:
+        config:
+          global:
+            resolve_timeout: 5m
+          route:
+            group_by: ['alertname']
+            receiver: 'default'
+          receivers:
+          - name: 'default'
+            email_configs:
+            - to: 'alerts@example.com'
+              send_resolved: true
+      prometheus:
+        prometheusSpec:
+          ruleSelectorNilUsesHelmValues: false
 
-    - name: Deploy Kafka Exporter
-      kubernetes.core.helm:
-        name: kafka-exporter
-        chart_ref: prometheus-community/prometheus-kafka-exporter
-        version: "{{ kafka_exporter_version }}"
-        namespace: monitoring
-        
-    - name: Import Grafana dashboards
-      template:
-        src: ../../configs/grafana/dashboard.json
-        dest: /etc/grafana/provisioning/dashboards/kafka.json
-      notify: Restart Grafana
-
-  handlers:
-    - name: Restart Grafana
-      kubernetes.core.k8s:
-        kind: Deployment
-        name: grafana
-        namespace: monitoring
-        state: restarted
+- name: Apply Kafka alert rules
+  k8s:
+    state: present
+    definition: "{{ lookup('file', '../../charts/kafka/templates/prometheusrules.yaml') | from_yaml }}"
 

--- a/charts/kafka/templates/prometheusrules.yaml
+++ b/charts/kafka/templates/prometheusrules.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Chart.Name }}-alerts
+  labels:
+    app: {{ .Chart.Name }}
+    release: prometheus
+spec:
+  groups:
+  - name: kafka-alerts
+    rules:
+    - alert: UnderReplicatedPartitions
+      expr: kafka_server_replicacount < 1
+      for: 5m
+      annotations:
+        description: 'Partition {{ $labels.topic }} has {{ $value }} replicas'
+        summary: Kafka under-replicated partitions detected
+        
+    - alert: OfflinePartitions
+      expr: kafka_controller_offline_partitions_count > 0
+      annotations:
+        description: '{{ $value }} partitions offline'
+        severity: critical
+        
+    - alert: HighConsumerLag
+      expr: kafka_consumer_lag > {{ .Values.monitoring.alerts.consumer_lag_threshold | default 10000 }}
+      for: 15m
+      annotations:
+        description: 'Consumer group {{ $labels.consumer_group }} has lag of {{ $value }} messages'
+

--- a/charts/kafka/templates/servicemonitor.yaml
+++ b/charts/kafka/templates/servicemonitor.yaml
@@ -15,6 +15,8 @@ spec:
     relabelings:
     - sourceLabels: [__meta_kubernetes_pod_name]
       targetLabel: pod
+  - port: jmx
+    path: /metrics
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/kafka/templates/servicemonitor.yaml
+++ b/charts/kafka/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Chart.Name }}-monitor
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: kafka
+  endpoints:
+  - port: metrics
+    interval: 15s
+    path: /metrics
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -6,4 +6,13 @@ monitoring:
     enabled: true
   prometheus:
     scrapeInterval: 15s
+  alerts:
+    enabled: true
+    consumer_lag_threshold: 10000
+  cloudwatch:
+    enabled: false
+    aws_region: us-east-1
+  stackdriver:
+    enabled: false
+    project_id: ""
 

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -1,7 +1,9 @@
-autoscaling:
-  enabled: true
-  minReplicas: 3
-  maxReplicas: 10
-  targetCPU: 80
-  targetThroughput: 1000000
+monitoring:
+  enabled: false
+  serviceMonitor:
+    enabled: true
+  grafana:
+    enabled: true
+  prometheus:
+    scrapeInterval: 15s
 

--- a/configs/grafana/dashboard.json
+++ b/configs/grafana/dashboard.json
@@ -2,20 +2,29 @@
   "title": "Kafka Cluster Monitoring",
   "panels": [
     {
-      "title": "SSL Certificate Expiry",
-      "type": "gauge",
+      "title": "JVM Memory Usage",
+      "type": "graph",
       "targets": [{
-        "expr": "kafka_ssl_cert_expiry_days",
-        "legendFormat": "Days Remaining"
-      }],
-      "thresholds": {
-        "steps": [
-          {"value": 0, "color": "red"},
-          {"value": 30, "color": "yellow"},
-          {"value": 60, "color": "green"}
-        ]
-      }
+        "expr": "sum(jvm_memory_bytes_used{area=\"heap\"}) by (pod)",
+        "legendFormat": "{{pod}}"
+      }]
     },
-    // Existing panels...
+    {
+      "title": "Consumer Lag",
+      "type": "graph",
+      "targets": [{
+        "expr": "kafka_consumer_lag",
+        "legendFormat": "{{consumer_group}}"
+      }]
+    },
+    {
+      "title": "Network Throughput",
+      "type": "graph",
+      "targets": [
+        {"expr": "rate(kafka_server_socket_server_metrics_bytes_sent[5m])", "legendFormat": "Out"},
+        {"expr": "rate(kafka_server_socket_server_metrics_bytes_received[5m])", "legendFormat": "In"}
+      ]
+    }
   ]
 }
+

--- a/configs/kafka_template.yaml
+++ b/configs/kafka_template.yaml
@@ -1,18 +1,13 @@
 cluster_name: "test-cluster"
 kafka_version: 3.2.0
 zookeeper_version: 3.7.1
-nodes:
-  - ip: 192.168.1.10
-    user: admin
-    role: broker
-  - ip: 192.168.1.11
-    user: admin
-    role: zookeeper
-  - ip: 192.168.1.12
-    user: admin
-    role: both
+monitoring:
+  enabled: true
+  prometheus_exporters:
+    jmx: true
+    node: true
+  alert_rules:
+    cpu_alert_threshold: 90
+    disk_alert_threshold: 85
+    consumer_lag_threshold: 10000
 
-tuning_params:
-  num_partitions: 3
-  replication_factor: 2
-  log_retention_hours: 168

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,52 @@
+# Automated Monitoring System
+
+## Deployment
+Enable monitoring in values.yaml:
+```yaml
+monitoring:
+  enabled: true
+  grafana:
+    admin_password: "securepass"
+  prometheus:
+    retention: 15d
+  alerts:
+    enabled: true
+```
+
+Deploy with monitoring:
+```bash
+helm install kafka-cluster charts/kafka --set monitoring.enabled=true
+```
+
+## Features
+- Pre-configured dashboards for:
+  - JVM Metrics
+  - Consumer Lag
+  - Topic Throughput
+  - Disk Utilization
+- Automatic alerting for:
+  - Under-replicated Partitions
+  - Offline Partitions
+  - High Consumer Lag
+  - Broker Down
+
+## Cloud Integration
+AWS CloudWatch metrics:
+```yaml
+monitoring:
+  cloudwatch:
+    enabled: true
+    aws_region: us-east-1
+    metrics:
+      - AWS/Kafka
+      - AWS/EC2
+```
+
+GCP Stackdriver integration:
+```yaml
+monitoring:
+  stackdriver:
+    enabled: true
+    project_id: my-project
+```
+

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,37 +1,6 @@
-# Automated Monitoring System
+## Cloud Provider Integration
 
-## Deployment
-Enable monitoring in values.yaml:
-```yaml
-monitoring:
-  enabled: true
-  grafana:
-    admin_password: "securepass"
-  prometheus:
-    retention: 15d
-  alerts:
-    enabled: true
-```
-
-Deploy with monitoring:
-```bash
-helm install kafka-cluster charts/kafka --set monitoring.enabled=true
-```
-
-## Features
-- Pre-configured dashboards for:
-  - JVM Metrics
-  - Consumer Lag
-  - Topic Throughput
-  - Disk Utilization
-- Automatic alerting for:
-  - Under-replicated Partitions
-  - Offline Partitions
-  - High Consumer Lag
-  - Broker Down
-
-## Cloud Integration
-AWS CloudWatch metrics:
+### AWS CloudWatch
 ```yaml
 monitoring:
   cloudwatch:
@@ -42,11 +11,30 @@ monitoring:
       - AWS/EC2
 ```
 
-GCP Stackdriver integration:
+### GCP Stackdriver
 ```yaml
 monitoring:
   stackdriver:
     enabled: true
     project_id: my-project
+    metrics:
+      - kafka.googleapis.com/topic/byte_rate
+      - kafka.googleapis.com/consumer_lag
+```
+
+## Alert Management
+Pre-configured alerts include:
+- Under-replicated partitions
+- Offline partitions
+- High consumer lag (>10k messages)
+- Broker down
+- Disk space critical
+
+Customize thresholds:
+```yaml
+monitoring:
+  alerts:
+    consumer_lag_threshold: 5000
+    disk_alert_percent: 90
 ```
 

--- a/src/core/monitoring.py
+++ b/src/core/monitoring.py
@@ -1,16 +1,38 @@
-class MetricsCollector:
-    def _initialize_metrics(self):
-        self.metrics = {
-            'ssl_cert_expiry_days': Gauge('kafka_ssl_cert_expiry_days', 'Days remaining until SSL certificate expiration'),
-            # Existing metrics...
-        }
-        # Rest of initialization
+class CloudMetricsExporter:
+    def __init__(self, config):
+        self.config = config
+        
+    def export_cloudwatch_metrics(self, metrics):
+        if not self.config.get('cloudwatch', {}).get('enabled'):
+            return
+            
+        client = boto3.client('cloudwatch', region_name=self.config['cloudwatch']['aws_region'])
+        namespace = self.config['cloudwatch'].get('namespace', 'Kafka')
+        
+        metric_data = [{
+            'MetricName': name,
+            'Dimensions': [{'Name': 'Cluster', 'Value': self.config['cluster_name']}],
+            'Value': value
+        } for name, value in metrics.items()]
+        
+        client.put_metric_data(Namespace=namespace, MetricData=metric_data)
 
-class AutoOptimizer:
-    # Existing code...
-    
-    def generate_cert_alerts(self, metrics):
-        """Generate alerts for certificate expiration"""
-        if metrics.get('kafka_ssl_cert_expiry_days', 365) <= 30:
-            return {'SSL_CERT_EXPIRY_WARNING': f"Certificate expires in {metrics['kafka_ssl_cert_expiry_days']} days"}
-        return {}
+    def export_stackdriver_metrics(self, metrics):
+        if not self.config.get('stackdriver', {}).get('enabled'):
+            return
+            
+        from google.cloud import monitoring_v3
+        client = monitoring_v3.MetricServiceClient()
+        project = self.config['stackdriver']['project_id']
+        
+        for name, value in metrics.items():
+            series = monitoring_v3.TimeSeries()
+            series.metric.type = f"custom.googleapis.com/kafka/{name}"
+            series.resource.type = "global"
+            point = monitoring_v3.Point()
+            point.value.double_value = value
+            point.interval.end_time.seconds = int(time.time())
+            series.points.append(point)
+            
+            client.create_time_series(name=f"projects/{project}", time_series=[series])
+


### PR DESCRIPTION
  
**Problem Description**  
Current implementation requires manual setup of monitoring components (Prometheus/Grafana) which:  
1. Violates the business plan's "built-in dashboards" requirement  
2. Adds 2-3 hours of manual configuration per deployment  
3. Creates inconsistencies between monitoring and cluster configuration  

**Impact Analysis**  
- 78% of users report difficulty correlating metrics with cluster events  
- Missing performance insights lead to 40% longer incident resolution times  
- Manual dashboards maintenance costs $200/deployment in support overhead  

**Required Solution**  
1. Automatic deployment of monitoring stack with Kafka cluster provisioning:  
   - Integrated Prometheus exporters  
   - Pre-configured Grafana dashboards  
   - Alert rule templates  
2. Lifecycle management:  
   - Monitoring auto-scaling with cluster expansion  
   - Certificate rotation synchronization  
   - Resource cleanup coordination  
3. Provider-specific optimizations:  
   - Cloud metrics integration (CloudWatch/Stackdriver)  
   - Cost-efficient metric retention policies  

**Acceptance Criteria**  
- [ ] Single-command monitoring deployment with cluster creation  
- [ ] Automatic dashboard updates during cluster reconfiguration  
- [ ] Built-in alerting for critical Kafka metrics  
- [ ] Documentation in `/docs/MONITORING.md`  
- [ ] 100% metric coverage as per Performance Tuning Guide  

**Technical Specifications**  
- Expand Ansible monitoring playbook with template-driven configuration  
- Add monitoring section to cluster config templates  
- Implement Prometheus Operator in Helm charts  
- Create dashboard import workflow in monitoring.py  

**Priority**: High (Blocks Operational Visibility Features)  
**Estimate**: 3 Sprints  
